### PR TITLE
Update CesiumMetadataPrimitive.cpp

### DIFF
--- a/Source/CesiumRuntime/Private/CesiumMetadataPrimitive.cpp
+++ b/Source/CesiumRuntime/Private/CesiumMetadataPrimitive.cpp
@@ -139,3 +139,131 @@ int64 UCesiumMetadataPrimitiveBlueprintLibrary::GetFirstVertexIDFromFaceID(
       },
       MetadataPrimitive._vertexIDAccessor);
 }
+
+int64 UCesiumMetadataPrimitiveBlueprintLibrary::GetSecondVertexIDFromFaceID(
+    UPARAM(ref) const FCesiumMetadataPrimitive& MetadataPrimitive,
+    int64 faceID) {
+  return std::visit(
+      [faceID](const auto& accessor) {
+        int64 index = faceID * 3 +1 ;
+
+        if (accessor.status() != CesiumGltf::AccessorViewStatus::Valid) {
+          // No indices, so each successive face is just the next three
+          // vertices.
+          return index;
+        } else if (index >= accessor.size()) {
+          // Invalid face index.
+          return -1LL;
+        }
+
+        return int64(accessor[index].value[0]);
+      },
+      MetadataPrimitive._vertexIDAccessor);
+}
+
+int64 UCesiumMetadataPrimitiveBlueprintLibrary::GetThirdVertexIDFromFaceID(
+    UPARAM(ref) const FCesiumMetadataPrimitive& MetadataPrimitive,
+    int64 faceID) {
+  return std::visit(
+      [faceID](const auto& accessor) {
+        int64 index = faceID * 3 + 2;
+
+        if (accessor.status() != CesiumGltf::AccessorViewStatus::Valid) {
+          // No indices, so each successive face is just the next three
+          // vertices.
+          return index;
+        } else if (index >= accessor.size()) {
+          // Invalid face index.
+          return -1LL;
+        }
+
+        return int64(accessor[index].value[0]);
+      },
+      MetadataPrimitive._vertexIDAccessor);
+}
+
+
+TMeshVector3
+UCesiumMetadataPrimitiveBlueprintLibrary::GetFirstVertexPositionFromFaceID(
+    UPARAM(ref) const FCesiumMetadataPrimitive& MetadataPrimitive,
+    int64 faceID) {
+  return std::visit(
+      [faceID](const auto& accessor,const auto& pAccessor) {
+        int64 index = faceID * 3;
+
+        if (accessor.status() != CesiumGltf::AccessorViewStatus::Valid ||
+            pAccessor.status() != CesiumGltf::AccessorViewStatus::Valid) {
+          // No indices, so each successive face is just the next three
+          // vertices.
+          return TMeshVector3();
+        } else if (index >= accessor.size()) {
+          // Invalid face index.
+          return TMeshVector3();
+        }
+        int64 pIndex = int64(accessor[index].value[0]);
+        if (pIndex >= pAccessor.size()) {
+          // Invalid face index.
+          return TMeshVector3();
+        }
+        return TMeshVector3(pAccessor[pIndex]);
+      },
+      MetadataPrimitive._vertexIDAccessor,
+      MetadataPrimitive._positionAccessor);
+}
+
+TMeshVector3
+UCesiumMetadataPrimitiveBlueprintLibrary::GetSecondVertexPositionFromFaceID(
+    UPARAM(ref) const FCesiumMetadataPrimitive& MetadataPrimitive,
+    int64 faceID) {
+  return std::visit(
+      [faceID](const auto& accessor, const auto& pAccessor) {
+        int64 index = faceID * 3 + 1;
+
+        if (accessor.status() != CesiumGltf::AccessorViewStatus::Valid ||
+            pAccessor.status() != CesiumGltf::AccessorViewStatus::Valid) {
+          // No indices, so each successive face is just the next three
+          // vertices.
+          return TMeshVector3();
+        } else if (index >= accessor.size()) {
+          // Invalid face index.
+          return TMeshVector3();
+        }
+        int64 pIndex = int64(accessor[index].value[0]);
+        if (pIndex >= pAccessor.size()) {
+          // Invalid face index.
+          return TMeshVector3();
+        }
+        return TMeshVector3(pAccessor[pIndex]);
+      },
+      MetadataPrimitive._vertexIDAccessor,
+      MetadataPrimitive._positionAccessor);
+}
+
+TMeshVector3
+UCesiumMetadataPrimitiveBlueprintLibrary::GetThirdVertexPositionFromFaceID(
+    UPARAM(ref) const FCesiumMetadataPrimitive& MetadataPrimitive,
+    int64 faceID) {
+  return std::visit(
+      [faceID](const auto& accessor, const auto& pAccessor) {
+        int64 index = faceID * 3 + 2;
+
+        if (accessor.status() != CesiumGltf::AccessorViewStatus::Valid ||
+            pAccessor.status() != CesiumGltf::AccessorViewStatus::Valid) {
+          // No indices, so each successive face is just the next three
+          // vertices.
+          return TMeshVector3();
+        } else if (index >= accessor.size()) {
+          // Invalid face index.
+          return TMeshVector3();
+        }
+        int64 pIndex = int64(accessor[index].value[0]);
+        if (pIndex >= pAccessor.size()) {
+          // Invalid face index.
+          return TMeshVector3();
+        }
+        return TMeshVector3(pAccessor[pIndex]);
+      },
+      MetadataPrimitive._vertexIDAccessor,
+      MetadataPrimitive._positionAccessor);
+}
+


### PR DESCRIPTION
add 5 methods:


  static int64 GetSecondVertexIDFromFaceID(
      UPARAM(ref) const FCesiumMetadataPrimitive& MetadataPrimitive,
      int64 FaceID);
  static int64 GetThirdVertexIDFromFaceID(
      UPARAM(ref) const FCesiumMetadataPrimitive& MetadataPrimitive,
      int64 FaceID);
  static TMeshVector3 GetFirstVertexPositionFromFaceID(
      UPARAM(ref) const FCesiumMetadataPrimitive& MetadataPrimitive,
      int64 faceID);
  static TMeshVector3 GetSecondVertexPositionFromFaceID(
      UPARAM(ref) const FCesiumMetadataPrimitive& MetadataPrimitive,
      int64 faceID);
  static TMeshVector3 GetThirdVertexPositionFromFaceID(
      UPARAM(ref) const FCesiumMetadataPrimitive& MetadataPrimitive,
      int64 faceID);